### PR TITLE
PVAYLADEV-809: Dependency change made possible by splitting xroad-common

### DIFF
--- a/packages/xroad-monitor-collector/redhat/SPECS/xroad-monitor-collector.spec
+++ b/packages/xroad-monitor-collector/redhat/SPECS/xroad-monitor-collector.spec
@@ -9,7 +9,7 @@ Release:            %{rel}%{?snapshot}%{?dist}
 Summary:            X-Road Monitoring Data Collector
 Group:              Applications/Internet
 License:            MIT
-Requires:           systemd, java-1.8.0-openjdk, xroad-common
+Requires:           systemd, java-1.8.0-openjdk, xroad-confclient
 Requires(post):     systemd
 Requires(preun):    systemd
 Requires(postun):   systemd


### PR DESCRIPTION
Xroad-common was recently split into subpackages, while xroad-common remains a metapackage consisting of all the parts. Of the new packages, xroad-monitor-collector only needs xroad-confclient (which depends on xroad-base).

This PR can be merged once X-Road d9ffa46 reaches the xroad-packages that monitor-collector depends on. (As that commit brings the split, xroad-confclient doesn't exist as a package in develop before that)