### PR TITLE
Migration from the Elasticsearch TransportClient to the Java High Level REST Client.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,8 +61,10 @@ repositories {
 }
 
 dependencies {
-    compile 'org.elasticsearch.client:transport:6.2.3'
-    compile 'org.elasticsearch:elasticsearch:6.2.3'
+    compile 'org.elasticsearch:elasticsearch:7.13.0'
+    compile 'org.elasticsearch.client:elasticsearch-rest-client:7.13.0'
+    compile 'org.elasticsearch.client:elasticsearch-rest-high-level-client:7.13.0'
+    compile 'org.apache.httpcomponents:httpcore:4.4.13' // needs to be explicitly set for the elasticsearch-rest-high-level-client
     compile group: 'org.springframework.boot', name: 'spring-boot-starter', version:'1.5.6.RELEASE'
     compile("org.springframework:spring-web")
     compile group: 'com.typesafe.akka', name: 'akka-actor_2.11', version:'2.5.1'

--- a/build_rpm.sh
+++ b/build_rpm.sh
@@ -20,7 +20,7 @@ rm -rf ${ROOT}/RPMS/*
 rm -rf ${ROOT}/SRPMS/*
 
 rpmbuild \
-    --define "xroad_monitor_collector_version 1.2.2" \
+    --define "xroad_monitor_collector_version 1.2.3" \
     --define "rel $RELEASE" \
     --define "snapshot $SNAPSHOT" \
     --define "_topdir $ROOT" \

--- a/build_rpm.sh
+++ b/build_rpm.sh
@@ -20,7 +20,7 @@ rm -rf ${ROOT}/RPMS/*
 rm -rf ${ROOT}/SRPMS/*
 
 rpmbuild \
-    --define "xroad_monitor_collector_version 1.2.1" \
+    --define "xroad_monitor_collector_version 1.2.2" \
     --define "rel $RELEASE" \
     --define "snapshot $SNAPSHOT" \
     --define "_topdir $ROOT" \

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-all.zip

--- a/src/integration-test/java/fi/vrk/xroad/monitor/actor/MonitorDataHandlerActorTest.java
+++ b/src/integration-test/java/fi/vrk/xroad/monitor/actor/MonitorDataHandlerActorTest.java
@@ -44,9 +44,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 
 import static fi.vrk.xroad.monitor.util.MonitorCollectorDataUtils.getIndexName;
 import static org.junit.Assert.assertEquals;
@@ -75,7 +75,7 @@ public class MonitorDataHandlerActorTest extends ElasticsearchTestBase {
    */
   @Before
   @After
-  public void cleanup() throws ExecutionException, InterruptedException {
+  public void cleanup() throws IOException {
     removeCurrentIndexAndAlias();
   }
 
@@ -85,7 +85,7 @@ public class MonitorDataHandlerActorTest extends ElasticsearchTestBase {
    * not been received.
    */
   @Test
-  public void testMonitorDataActor() throws ExecutionException, InterruptedException {
+  public void testMonitorDataActor() throws IOException {
 
     // create result collector actor
     final Props resultCollectorActorProps = Props.create(ResultCollectorActor.class);

--- a/src/integration-test/java/fi/vrk/xroad/monitor/actor/SupervisorTest.java
+++ b/src/integration-test/java/fi/vrk/xroad/monitor/actor/SupervisorTest.java
@@ -45,9 +45,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -91,7 +91,7 @@ public class SupervisorTest extends ElasticsearchTestBase {
      */
     @Before
     @After
-    public void cleanup() throws ExecutionException, InterruptedException {
+    public void cleanup() throws IOException {
         removeCurrentIndexAndAlias();
     }
 

--- a/src/integration-test/java/fi/vrk/xroad/monitor/base/ElasticsearchTestBase.java
+++ b/src/integration-test/java/fi/vrk/xroad/monitor/base/ElasticsearchTestBase.java
@@ -31,7 +31,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.util.concurrent.ExecutionException;
+import java.io.IOException;
 
 /**
  * Base class for Elasticsearch tests
@@ -47,19 +47,19 @@ public abstract class ElasticsearchTestBase {
   @Autowired
   protected Environment environment;
 
-  protected void removeIndex(String index) {
-    if (envMonitorDataStorageDao.indexExists(index).isExists()) {
+  protected void removeIndex(String index) throws IOException {
+    if (envMonitorDataStorageDao.indexExists(index)) {
       envMonitorDataStorageDao.removeIndex(index);
     }
   }
 
-  protected void removeCurrentIndexAndAlias() throws ExecutionException, InterruptedException {
+  protected void removeCurrentIndexAndAlias() throws IOException {
     removeAlias(environment.getProperty("xroad-monitor-collector-elasticsearch.alias"));
     removeIndex(MonitorCollectorDataUtils.getIndexName(environment));
   }
 
-  protected void removeAlias(String alias) throws ExecutionException, InterruptedException {
-    if (envMonitorDataStorageDao.aliasExists(alias).isExists()) {
+  protected void removeAlias(String alias) throws IOException {
+    if (envMonitorDataStorageDao.aliasExists(alias)) {
       envMonitorDataStorageDao.removeAllIndexesFromAlias(alias);
     }
   }

--- a/src/main/java/fi/vrk/xroad/monitor/actor/ElasticsearchInitializerActor.java
+++ b/src/main/java/fi/vrk/xroad/monitor/actor/ElasticsearchInitializerActor.java
@@ -29,7 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.ExecutionException;
+import java.io.IOException;
 
 /**
  * Actor for initializing Elasticsearch index and alias
@@ -50,7 +50,7 @@ public class ElasticsearchInitializerActor extends AbstractActor {
         .build();
   }
 
-  private void handleInitialization(String s) throws ExecutionException, InterruptedException {
+  private void handleInitialization(String s) throws IOException {
     // for tests it is ok for envMonitorDataStorageService to be null
     if (envMonitorDataStorageService != null) {
       log.info("Create index and update alias");

--- a/src/main/java/fi/vrk/xroad/monitor/actor/MonitorDataHandlerActor.java
+++ b/src/main/java/fi/vrk/xroad/monitor/actor/MonitorDataHandlerActor.java
@@ -99,7 +99,7 @@ public class MonitorDataHandlerActor extends AbstractActor {
             // monitoring data was not received from security server or save operation failed
             // store only default data
             log.info("save default data for security server {}", request.getSecurityServerInfo());
-            envMonitorDataStorageService.save(extractor.getDefaultJSON(request.getSecurityServerInfo()));
+            envMonitorDataStorageService.save(extractor.getDefaultJSON(request.getSecurityServerInfo(), errorString));
             resultCollectorActor.tell(ResultCollectorActor.Result.createError(
                 request.getSecurityServerInfo(), errorString), getSelf());
         }

--- a/src/main/java/fi/vrk/xroad/monitor/elasticsearch/EnvMonitorDataStorageDao.java
+++ b/src/main/java/fi/vrk/xroad/monitor/elasticsearch/EnvMonitorDataStorageDao.java
@@ -22,17 +22,13 @@
  */
 package fi.vrk.xroad.monitor.elasticsearch;
 
-import org.elasticsearch.action.admin.indices.alias.IndicesAliasesResponse;
-import org.elasticsearch.action.admin.indices.alias.exists.AliasesExistResponse;
-import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
-import org.elasticsearch.action.admin.indices.delete.DeleteIndexResponse;
-import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsResponse;
 import org.elasticsearch.action.admin.indices.flush.FlushResponse;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.indices.CreateIndexResponse;
 
-import java.util.concurrent.ExecutionException;
+import java.io.IOException;
 
 /**
  * Interface for loading/saving env monitor data
@@ -42,47 +38,47 @@ public interface EnvMonitorDataStorageDao {
   /**
    * Save data
    */
-  IndexResponse save(String index, String type, String json);
+  IndexResponse save(String index, String type, String json) throws IOException;
 
   /**
    * Load data
    */
-  GetResponse load(String index, String type, String key);
+  GetResponse load(String index, String type, String key) throws IOException;
 
   /**
    * Create alias for given index
    * @param index
    * @param alias
    */
-  IndicesAliasesResponse addIndexToAlias(String index, String alias) throws ExecutionException, InterruptedException;
+  boolean addIndexToAlias(String index, String alias) throws  IOException;
 
   /**
    * Remove all indexes from alias
    * @param alias
    * @return
    */
-  IndicesAliasesResponse removeAllIndexesFromAlias(String alias);
+  boolean removeAllIndexesFromAlias(String alias) throws IOException;
 
   /**
    * Tests if given alias exists
    * @param alias
    * @return
    */
-  AliasesExistResponse aliasExists(String alias) throws ExecutionException, InterruptedException;
+  boolean aliasExists(String alias) throws IOException;
 
   /**
    * Tests if given index exists
    * @param index
    * @return
    */
-  IndicesExistsResponse indexExists(String index);
+  boolean indexExists(String index) throws IOException;
 
   /**
    * Removes given index
    * @param index
    * @return
    */
-  DeleteIndexResponse removeIndex(String index);
+  boolean removeIndex(String index) throws IOException;
 
   /**
    * Find all documents from given index and type
@@ -90,18 +86,18 @@ public interface EnvMonitorDataStorageDao {
    * @param type
    * @return search response
    */
-  SearchResponse findAll(String index, String type);
+  SearchResponse findAll(String index, String type) throws IOException;
 
   /**
    * Flush index operations
    * @return flush response
    */
-  FlushResponse flush() throws ExecutionException, InterruptedException;
+  FlushResponse flush() throws IOException;
 
   /**
    * Create index
    * @return create index response
    */
-  CreateIndexResponse createIndex(String index) throws ExecutionException, InterruptedException;
+  CreateIndexResponse createIndex(String index) throws IOException;
 
 }

--- a/src/main/java/fi/vrk/xroad/monitor/elasticsearch/EnvMonitorDataStorageDaoImpl.java
+++ b/src/main/java/fi/vrk/xroad/monitor/elasticsearch/EnvMonitorDataStorageDaoImpl.java
@@ -109,7 +109,7 @@ public class EnvMonitorDataStorageDaoImpl implements EnvMonitorDataStorageDao {
 
   @Override
   public boolean removeAllIndexesFromAlias(String alias) throws IOException {
-    DeleteAliasRequest request = new DeleteAliasRequest("*", alias);
+    DeleteAliasRequest request = new DeleteAliasRequest("straumurinn-is-*", alias);
     org.elasticsearch.client.core.AcknowledgedResponse indicesAliasesResponse =
             client.indices().deleteAlias(request, RequestOptions.DEFAULT);
     return indicesAliasesResponse.isAcknowledged();

--- a/src/main/java/fi/vrk/xroad/monitor/elasticsearch/EnvMonitorDataStorageService.java
+++ b/src/main/java/fi/vrk/xroad/monitor/elasticsearch/EnvMonitorDataStorageService.java
@@ -22,7 +22,7 @@
  */
 package fi.vrk.xroad.monitor.elasticsearch;
 
-import java.util.concurrent.ExecutionException;
+import java.io.IOException;
 
 /**
  * Interface for Elasticsearch data storage service
@@ -33,10 +33,10 @@ public interface EnvMonitorDataStorageService {
    * Save json to Elasticsearch
    * @param json
    */
-  void save(String json) throws ExecutionException, InterruptedException;
+  void save(String json) throws IOException;
 
   /**
    * Update alias
    */
-  void createIndexAndUpdateAlias() throws ExecutionException, InterruptedException;
+  void createIndexAndUpdateAlias() throws IOException;
 }

--- a/src/main/java/fi/vrk/xroad/monitor/elasticsearch/EnvMonitorDataStorageServiceImpl.java
+++ b/src/main/java/fi/vrk/xroad/monitor/elasticsearch/EnvMonitorDataStorageServiceImpl.java
@@ -28,7 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
-import java.util.concurrent.ExecutionException;
+import java.io.IOException;
 
 import static fi.vrk.xroad.monitor.util.MonitorCollectorDataUtils.getIndexName;
 
@@ -46,7 +46,7 @@ public class EnvMonitorDataStorageServiceImpl implements EnvMonitorDataStorageSe
   private Environment environment;
 
   @Override
-  public synchronized void save(String json) throws ExecutionException, InterruptedException {
+  public synchronized void save(String json) throws IOException {
     final String index = getIndexName(environment);
     final String type = environment.getProperty("xroad-monitor-collector-elasticsearch.type");
     log.debug("Store data to index: {}", index);
@@ -55,13 +55,13 @@ public class EnvMonitorDataStorageServiceImpl implements EnvMonitorDataStorageSe
   }
 
   @Override
-  public synchronized void createIndexAndUpdateAlias() throws ExecutionException, InterruptedException {
+  public synchronized void createIndexAndUpdateAlias() throws IOException {
     final String index = getIndexName(environment);
     final String alias = environment.getProperty("xroad-monitor-collector-elasticsearch.alias");
-    if (!envMonitorDataStorageDao.indexExists(index).isExists()) {
+    if (!envMonitorDataStorageDao.indexExists(index)) {
       log.info("Create index {}", index);
       envMonitorDataStorageDao.createIndex(index);
-      if (envMonitorDataStorageDao.aliasExists(alias).exists()) {
+      if (envMonitorDataStorageDao.aliasExists(alias)) {
         log.info("Alias exists, remove all indexes from alias {}", alias);
         envMonitorDataStorageDao.removeAllIndexesFromAlias(alias);
       } else {

--- a/src/main/java/fi/vrk/xroad/monitor/extractor/MonitorDataExtractor.java
+++ b/src/main/java/fi/vrk/xroad/monitor/extractor/MonitorDataExtractor.java
@@ -126,8 +126,9 @@ public class MonitorDataExtractor {
      * @param info security server information
      * @return default JSON
      */
-    public String getDefaultJSON(SecurityServerInfo info) {
-        return responseParser.getDefaultJSON(info, environment.getProperty(MonitorCollectorPropertyKeys.INSTANCE));
+    public String getDefaultJSON(SecurityServerInfo info, String errorString) {
+        return responseParser.getDefaultJSON(
+                info, environment.getProperty(MonitorCollectorPropertyKeys.INSTANCE), errorString);
     }
 
     /**

--- a/src/main/java/fi/vrk/xroad/monitor/extractor/MonitorDataResponseParser.java
+++ b/src/main/java/fi/vrk/xroad/monitor/extractor/MonitorDataResponseParser.java
@@ -107,7 +107,7 @@ public class MonitorDataResponseParser {
      * @param xroadInstance X-Road instance
      * @return JSON formatted string containing the default data
      */
-    public String getDefaultJSON(SecurityServerInfo info, String xroadInstance) {
+    public String getDefaultJSON(SecurityServerInfo info, String xroadInstance, String errorString) {
         JSONObject json = new JSONObject();
         json.put("serverCode", info.getServerCode());
         json.put("memberCode", info.getMemberCode());
@@ -115,6 +115,7 @@ public class MonitorDataResponseParser {
         json.put("xroadInstance", xroadInstance);
         json.put("name", String.format("SERVER:%s/%s/%s/%s", xroadInstance, info.getMemberClass(),
             info.getMemberCode(), info.getServerCode()));
+        json.put("error", errorString);
         return json.toString();
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,7 +20,8 @@ xroad-monitor-collector.query-parameters=OperatingSystem,Processes
 # elasticsearch information
 xroad-monitor-collector-elasticsearch.cluster=aws-elk
 xroad-monitor-collector-elasticsearch.host=elkdev-es3.i.palveluvayla.com
-xroad-monitor-collector-elasticsearch.port=9300
+xroad-monitor-collector-elasticsearch.port=9200
+xroad-monitor-collector-elasticsearch.scheme=http
 xroad-monitor-collector-elasticsearch.index=integrationtest-envdata
 xroad-monitor-collector-elasticsearch.type=integrationtest-envdata
 xroad-monitor-collector-elasticsearch.alias=integrationtest-envdata-latest


### PR DESCRIPTION
Using the REST interface enables communication with Elasticsearch version 7 and should be more or less version agnostic.  Furthermore, this allows using the Amazon Elasticsearch Service, [which does not support the TCP transport](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-supported-resources.html).